### PR TITLE
Fix enacted status detection

### DIFF
--- a/tests/test_is_enacted.py
+++ b/tests/test_is_enacted.py
@@ -1,0 +1,23 @@
+import sys
+import pathlib
+
+# Add backend module path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "backend"))
+
+from main import is_enacted
+
+
+def test_is_enacted_true_for_public_law_range():
+    assert is_enacted(36000)
+    assert is_enacted(36500)
+    assert is_enacted(39999)
+
+
+def test_is_enacted_true_for_private_law_range():
+    assert is_enacted(41000)
+    assert is_enacted(44999)
+
+
+def test_is_enacted_false_outside_ranges():
+    for code in [35999, 40001, 45000, None, "invalid"]:
+        assert not is_enacted(code)


### PR DESCRIPTION
## Summary
- detect enacted bills using action-code ranges instead of fixed values
- add tests for `is_enacted` helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab98adab0c832eae8fff02cc508afa