### PR TITLE
Improve law detection and expose public/private law counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ uvicorn main:app --reload
 
 ## Notes
 
-- "Became Law" is computed from **action codes** in `latestAction.actionCode`, using Congress.gov’s values for public/private law:
-  36000–40000 (public law) and 41000–45000 (private law).
+- "Became Law" is determined from a bill's `laws.type` ("Public Law" or "Private Law") when available, falling back to the
+  `latestAction.actionCode` ranges 36000–39999 (public law) and 41000–44999 (private law). Counts for public and private laws
+  are provided separately.
 - Counting "passed both chambers" is possible by scanning each bill’s full action history (slower).
 
 ## License

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -51,6 +51,8 @@ function render() {
       <td>${r.party || '—'}</td>
       <td>${r.state || '—'}</td>
       <td class="right">${fmt(r.sponsored_total || 0)}</td>
+      <td class="right">${fmt(r.public_law_total || 0)}</td>
+      <td class="right">${fmt(r.private_law_total || 0)}</td>
       <td class="right">${fmt(r.enacted_total || 0)}</td>
     </tr>
   `).join('');
@@ -85,7 +87,8 @@ headers.forEach(th => {
       sortDir = sortDir === 'asc' ? 'desc' : 'asc';
     } else {
       sortKey = key;
-      sortDir = (key === 'sponsored_total' || key === 'enacted_total') ? 'desc' : 'asc';
+      sortDir = (key === 'sponsored_total' || key === 'enacted_total' ||
+                 key === 'public_law_total' || key === 'private_law_total') ? 'desc' : 'asc';
     }
     render();
   });

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -11,7 +11,7 @@
   <div class="container">
     <header class="mb">
       <h1 class="h1">Congress Bill Stats</h1>
-      <p class="muted">Counts of bills sponsored and enacted (became law) by legislator. Data: Congress.gov API.</p>
+      <p class="muted">Counts of bills sponsored and enacted (became law) by legislator, with public vs. private law breakdown. Data: Congress.gov API.</p>
     </header>
 
     <section class="controls">
@@ -48,6 +48,8 @@
             <th data-key="party" class="th-sort">Party</th>
             <th data-key="state" class="th-sort">State</th>
             <th data-key="sponsored_total" class="th-sort right">Sponsored</th>
+            <th data-key="public_law_total" class="th-sort right">Public Law</th>
+            <th data-key="private_law_total" class="th-sort right">Private Law</th>
             <th data-key="enacted_total" class="th-sort right">Became Law</th>
           </tr>
         </thead>
@@ -56,7 +58,7 @@
     </div>
 
     <p class="tiny muted">
-      “Became Law” uses Congress.gov action codes for enacted public/private laws. First load may take a few minutes; then it’s cached.
+      “Became Law” relies on each bill’s law type or action codes for public/private laws. First load may take a few minutes; then it’s cached.
     </p>
   </div>
 

--- a/tests/test_build_stats.py
+++ b/tests/test_build_stats.py
@@ -51,5 +51,8 @@ def test_build_stats_counts_enacted(monkeypatch):
     monkeypatch.setattr(main, "api_get", fake_api_get)
 
     stats = main.build_stats(118, use_cache=False)
-    assert stats["rows"][0]["enacted_total"] == 1
-    assert stats["rows"][0]["sponsored_total"] == 1
+    row = stats["rows"][0]
+    assert row["enacted_total"] == 1
+    assert row["public_law_total"] == 1
+    assert row["private_law_total"] == 0
+    assert row["sponsored_total"] == 1

--- a/tests/test_is_enacted.py
+++ b/tests/test_is_enacted.py
@@ -4,7 +4,7 @@ import pathlib
 # Add backend module path
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "backend"))
 
-from main import is_enacted
+from main import is_enacted, law_type_from_action_code
 
 
 def test_is_enacted_true_for_public_law_range():
@@ -21,3 +21,9 @@ def test_is_enacted_true_for_private_law_range():
 def test_is_enacted_false_outside_ranges():
     for code in [35999, 40001, 45000, None, "invalid"]:
         assert not is_enacted(code)
+
+
+def test_law_type_from_action_code():
+    assert law_type_from_action_code(36000) == "Public Law"
+    assert law_type_from_action_code(44999) == "Private Law"
+    assert law_type_from_action_code(1) is None


### PR DESCRIPTION
## Summary
- interpret Congress.gov action codes to detect public vs private laws
- tally public and private law totals per sponsor and surface in UI
- document law type handling in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb1b4860832e89ceb763afc859a0